### PR TITLE
Context menu "Open LOVE 2D documentation" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
             "editor/context": [
                 {
                     "command": "LOVE.openDocumentation",
-                    "group": "Love",
-                    "when": "editorTextFocus && config.bookmarks.showCommandsInContextMenu"
+                    "group": "navigation@LOVE"
                 }
             ]
         }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
                 "command": "LOVE.launch",
                 "key": "Alt+L"
             }
-        ]
+        ],
         "menus": {
             "editor/context": [
                 {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,15 @@
                 "key": "Alt+L"
             }
         ]
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "LOVE.openDocumentation",
+                    "group": "Love",
+                    "when": "editorTextFocus && config.bookmarks.showCommandsInContextMenu"
+                }
+            ]
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",


### PR DESCRIPTION
Added a chunk of code to the `package.json` file to add the open documentation function to the context menu. Right clicking on something like `love.graphics` will now pop up a context menu option to Open the documentation.
![image](https://github.com/user-attachments/assets/91db48ff-0f8b-4769-9a88-c6d379177424)
